### PR TITLE
Articleの記事一覧のAPIを実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,4 +10,4 @@ AllCops:
   TargetRubyVersion: 2.7  
 
 RSpec/MultipleExpectations:
-  Max: 3
+  Max: 5

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ gem "jbuilder", "~> 2.7"
 # gem 'image_processing', '~> 1.2'
 
 # Reduces boot times through caching; required in config/boot.rb
-gem "active_model_serializers"
+gem "active_model_serializers", "~> 0.10.0"
 gem "bootsnap", ">= 1.4.4", require: false
 gem "devise_token_auth"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,7 +305,7 @@ PLATFORMS
   x86_64-darwin-22
 
 DEPENDENCIES
-  active_model_serializers
+  active_model_serializers (~> 0.10.0)
   annotate
   bootsnap (>= 1.4.4)
   byebug

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,0 +1,8 @@
+module Api::V1
+  class ArticlesController < BaseApiController
+    def index
+      @articles = Article.all.order(updated_at: :desc)
+      render json: @articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+  end
+end

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,0 +1,5 @@
+class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
+  attributes :id, :title, :updated_at
+
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/app/serializers/api/v1/user_serializer.rb
+++ b/app/serializers/api/v1/user_serializer.rb
@@ -1,0 +1,3 @@
+class Api::V1::UserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :email
+end

--- a/spec/requests/api/v1/article_request_spec.rb
+++ b/spec/requests/api/v1/article_request_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Articles", type: :request do
+  describe "GET /articles" do
+    subject { get(api_v1_articles_path) }
+
+    let!(:article1) { create(:article, updated_at: 1.days.ago) }
+    let!(:article2) { create(:article, updated_at: 2.days.ago) }
+    let!(:article3) { create(:article) }
+
+    it "記事一覧が取得できる" do
+      subject
+      res = JSON.parse(response.body)
+
+      expect(res.length).to eq 3 # 全ての記事が表示される
+      expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+      expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+      expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+      expect(response).to have_http_status(:ok)
+    end
+  end
+end


### PR DESCRIPTION
##概要
- ActiveModelSerializerを使用して記事一覧のserializerを作成
- ActiveModelSerializerを使用してUserのserializerを作成
- ArticlesControllerを作成し、index メソッドを記載
- Request specでテストを実施