### PR TITLE
既存APIの修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,5 +1,7 @@
 module Api::V1
   class ArticlesController < BaseApiController
+    skip_before_action :authenticate_user!, only: %i[index show]
+
     def index
       articles = Article.all.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::BaseApiController < ApplicationController
-  private
+  before_action :authenticate_user!
 
-    def current_user
-      @current_user ||= User.first
-    end
+  alias_method :current_user, :current_api_v1_user
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end


### PR DESCRIPTION
##概要
- ダミーメソッドを削除
- alias_methodでmethod名を省略して定義
- 記事一覧、詳細以外はauthenticate_user!で弾くように実装
- articleのテストでallow_any_instance_ofを使用していたものを実装が完了したので、ヘッダー情報を渡すように変更