### PR TITLE
記事の下書き/公開に関するAPIの修正を実施

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -3,12 +3,12 @@ module Api::V1
     skip_before_action :authenticate_user!, only: %i[index show]
 
     def index
-      articles = Article.all.order(updated_at: :desc)
+      articles = Article.published.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
 
     def show
-      article = Article.find(params[:id])
+      article = Article.published.find(params[:id])
       render json: article, serializer: Api::V1::ArticleSerializer
     end
 
@@ -40,7 +40,7 @@ module Api::V1
     private
 
       def article_params
-        params.require(:article).permit(:title, :body)
+        params.require(:article).permit(:title, :body, :status)
       end
   end
 end

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,5 +1,5 @@
 class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
-  attributes :id, :title, :updated_at
+  attributes :id, :title, :status, :updated_at
 
   belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,5 +1,5 @@
 class Api::V1::ArticleSerializer < ActiveModel::Serializer
-  attributes :id, :title, :body, :updated_at
+  attributes :id, :title, :body, :status, :updated_at
 
   belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -20,7 +20,7 @@ RSpec/EmptyLineAfterFinalLet:
 # feature spec は exclude でも良いかもしれない。
 # ヒアドキュメント使うと一瞬で超えるので disable も検討。
 RSpec/ExampleLength:
-  Max: 10
+  Max: 11
 
 # block の方がテスト対象が
 # * `{}` の前後のスペースと相まって目立つ

--- a/spec/requests/api/v1/article_request_spec.rb
+++ b/spec/requests/api/v1/article_request_spec.rb
@@ -4,17 +4,19 @@ RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET / articles" do
     subject { get(api_v1_articles_path) }
 
-    let!(:article1) { create(:article, updated_at: 1.days.ago) }
-    let!(:article2) { create(:article, updated_at: 2.days.ago) }
-    let!(:article3) { create(:article) }
+    let!(:article1) { create(:article, :published, updated_at: 1.days.ago) }
+    let!(:article2) { create(:article, :published, updated_at: 2.days.ago) }
+    let!(:article3) { create(:article, :published) }
 
-    it "記事一覧が取得できる" do
+    before { create(:article, :draft) }
+
+    it "公開記事一覧が降順で取得できる" do
       subject
       res = JSON.parse(response.body)
 
       expect(res.length).to eq 3 # 全ての記事が表示される
       expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
-      expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
+      expect(res[0].keys).to eq ["id", "title", "status", "updated_at", "user"]
       expect(res[0]["user"].keys).to eq ["id", "name", "email"]
       expect(response).to have_http_status(:ok)
     end
@@ -23,8 +25,8 @@ RSpec.describe "Api::V1::Articles", type: :request do
   describe "GET /articles/:id" do
     subject { get(api_v1_article_path(article_id)) }
 
-    context "指定したidの記事が存在するとき" do
-      let(:article) { create(:article) }
+    context "指定したidの公開記事が存在するとき" do
+      let(:article) { create(:article, :published) }
       let(:article_id) { article.id }
 
       it "その記事が取得できる" do
@@ -34,11 +36,21 @@ RSpec.describe "Api::V1::Articles", type: :request do
         expect(res["id"]).to eq article.id
         expect(res["title"]).to eq article.title
         expect(res["body"]).to eq article.body
+        expect(res["status"]).to eq "published"
         expect(res["updated_at"]).to be_present
-        expect(res.keys).to eq ["id", "title", "body", "updated_at", "user"]
+        expect(res.keys).to eq ["id", "title", "body", "status", "updated_at", "user"]
         expect(res["user"]["id"]).to eq article.user.id
         expect(res["user"].keys).to eq ["id", "name", "email"]
         expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "対象の記事が下書き状態であるとき" do
+      let(:article) { create(:article, :draft) }
+      let(:article_id) { article.id }
+
+      it "記事が見つからない" do
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
       end
     end
 
@@ -57,29 +69,39 @@ RSpec.describe "Api::V1::Articles", type: :request do
     let!(:user) { create(:user) }
     let!(:headers) { user.create_new_auth_token }
 
-    context "適切なパラメータを送信したとき" do
+    context "公開記事作成に適切なパラメータを送信したとき" do
       let(:params) do
-        { article: attributes_for(:article) }
+        { article: attributes_for(:article, :published) }
       end
 
-      it "記事が作成できる" do
+      it "公開記事が作成できる" do
         expect { subject }.to change { Article.where(user_id: user.id).count }.by(1)
         res = JSON.parse(response.body)
         expect(res["title"]).to eq params[:article][:title]
         expect(res["body"]).to eq params[:article][:body]
+        expect(res["status"]).to eq "published"
         expect(response).to have_http_status(:created)
-        # header = response.headers
-        # expect(header["access-token"]).to eq params[:article][:headers]["access-token"]
-        # expect(header["uid"]).to eq params[:article][:headers]["uid"]
-        # expect(header["client"]).to eq params[:article][:headers]["client"]
+      end
+    end
+
+    context "下書き記事作成に必要なパラメーターを送信したとき" do
+      let(:params) { { article: attributes_for(:article, :draft) } }
+
+      it "下書き記事が作成できる" do
+        expect { subject }.to change { Article.count }.by(1)
+        res = JSON.parse(response.body)
+        expect(res["status"]).to eq "draft"
+        expect(response).to have_http_status(:created)
       end
     end
 
     context "不適切なバラメーターを送信したとき" do
-      let(:params) { attributes_for(:article) }
+      let(:params) do
+        { article: attributes_for(:article, status: :x) }
+      end
 
       it "エラーが発生する" do
-        expect { subject }.to raise_error { ActionController::ParameterMissing }
+        expect { subject }.to raise_error { ArgumentError }
       end
     end
   end
@@ -87,16 +109,17 @@ RSpec.describe "Api::V1::Articles", type: :request do
   describe "PATCH /api/v1/articles/:id" do
     subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
 
-    let(:params) { { article: attributes_for(:article) } }
+    let(:params) { { article: attributes_for(:article, :published) } }
     let(:user) { create(:user) }
     let!(:headers) { user.create_new_auth_token }
 
     context "自分が所持している記事のレコードを更新しようとするとき" do
-      let(:article) { create(:article, body: "BODY", user: user) }
+      let(:article) { create(:article, body: "BODY", status: :draft, user: user) }
 
       it "記事を更新できる" do
         expect { subject }.to change { article.reload.title }.from(article.title).to(params[:article][:title]) &
-                              change { article.reload.body }.from(article.body).to(params[:article][:body])
+                              change { article.reload.body }.from(article.body).to(params[:article][:body]) &
+                              change { article.reload.status }.from(article.status).to(params[:article][:status].to_s)
         expect(response).to have_http_status(:ok)
       end
     end


### PR DESCRIPTION
##概要
- 記事一覧・詳細では公開記事だけ取得出来るように修正
- 記事の作成・更新時に公開・非公開を選択できるように修正
- 上記修正に関するテストを追加で実施