### PR TITLE
下書き記事一覧/詳細のAPIを実装

### DIFF
--- a/app/controllers/api/v1/articles/drafts_controller.rb
+++ b/app/controllers/api/v1/articles/drafts_controller.rb
@@ -1,0 +1,13 @@
+module Api::V1
+  class Articles::DraftsController < BaseApiController
+    def index
+      articles = current_user.articles.draft.order(updated_at: :desc)
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+
+    def show
+      article = current_user.articles.draft.find(params[:id])
+      render json: article, serializer: Api::V1::ArticleSerializer
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,10 @@ Rails.application.routes.draw do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
         registrations: "api/v1/auth/registrations",
       }
+
+      namespace :articles do
+        resources :drafts, only: [:index, :show]
+      end
       resources :articles
     end
   end

--- a/spec/requests/api/v1/articles/draft_request_spec.rb
+++ b/spec/requests/api/v1/articles/draft_request_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe "Articles::DraftsController", type: :request do
+  describe "GET / api/v1/articles/drafts" do
+    subject { get(api_v1_articles_drafts_path, headers: headers) }
+
+    let!(:user) { create(:user) }
+    let!(:headers) { user.create_new_auth_token }
+
+    let!(:article1) { create(:article, :draft, updated_at: 1.days.ago, user: user) }
+    let!(:article2) { create(:article, :draft, updated_at: 2.days.ago, user: user) }
+    let!(:article3) { create(:article, :draft, user: user) }
+
+    before { create(:article, :published, user: user) }
+
+    it "下書き記事一覧が降順に取得できる" do
+      subject
+      res = JSON.parse(response.body)
+
+      expect(res.length).to eq 3 # 全ての記事が表示される
+      expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+      expect(res[0].keys).to eq ["id", "title", "status", "updated_at", "user"]
+      expect(res[0]["user"].keys).to eq ["id", "name", "email"]
+      expect(response).to have_http_status(:ok)
+    end
+  end
+
+  describe "GET / api/v1/articles/drafts/:id" do
+    subject { get(api_v1_articles_draft_path(article_id), headers: headers) }
+
+    let!(:user) { create(:user) }
+    let!(:headers) { user.create_new_auth_token }
+
+    context "指定したidの下書き記事が存在するとき" do
+      let(:article) { create(:article, :draft, user: user) }
+      let(:article_id) { article.id }
+
+      it "その記事が取得できる" do
+        subject
+        res = JSON.parse(response.body)
+
+        expect(res["id"]).to eq article.id
+        expect(res["title"]).to eq article.title
+        expect(res["body"]).to eq article.body
+        expect(res["status"]).to eq "draft"
+        expect(res["updated_at"]).to be_present
+        expect(res.keys).to eq ["id", "title", "body", "status", "updated_at", "user"]
+        expect(res["user"]["id"]).to eq article.user.id
+        expect(res["user"].keys).to eq ["id", "name", "email"]
+        expect(response).to have_http_status(:ok)
+      end
+    end
+
+    context "指定したidの記事が公開記事のとき" do
+      let(:article) { create(:article, :published, user: user) }
+      let(:article_id) { article.id }
+
+      it "記事が見つからない" do
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+
+    context "指定したidの下書き記事が存在しないどき" do
+      let(:article_id) { 1000 }
+
+      it "記事が見つからない" do
+        expect { subject }.to raise_error ActiveRecord::RecordNotFound
+      end
+    end
+  end
+end


### PR DESCRIPTION
##概要
- articles配下にdrafts_controllerを作成
- routes.rbにindexとshowのエンドポイントを/api/v1/articles/draftsに設定
- テストを実装